### PR TITLE
Removes notice for CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/pdfcrowd.php
+++ b/pdfcrowd.php
@@ -626,7 +626,7 @@ Links:
 
         if ($this->scheme == 'https' && HOST == 'api.pdfcrowd.com') {
             curl_setopt($c, CURLOPT_SSL_VERIFYPEER, true);
-            curl_setopt($c, CURLOPT_SSL_VERIFYHOST, true);
+            curl_setopt($c, CURLOPT_SSL_VERIFYHOST, 2);
         } else {
             curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
             curl_setopt($c, CURLOPT_SSL_VERIFYHOST, false);


### PR DESCRIPTION
Without this fix, PHP (v. 7.0.20) throws the following notice:

Notice: curl_setopt(): CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead